### PR TITLE
EVG-7782: Make execution options general for all getters

### DIFF
--- a/buildlogger/get.go
+++ b/buildlogger/get.go
@@ -23,7 +23,6 @@ type BuildloggerGetOptions struct {
 	GroupID       string
 	Start         time.Time
 	End           time.Time
-	Execution     int
 	ProcessName   string
 	Tags          []string
 	PrintTime     bool
@@ -63,7 +62,7 @@ func (opts *BuildloggerGetOptions) parse() (string, error) {
 
 	params := fmt.Sprintf(
 		"?execution=%d&proc_name=%s&print_time=%v&print_priority=%v&n=%d&limit=%d&paginate=true",
-		opts.Execution,
+		opts.CedarOpts.Execution,
 		opts.ProcessName,
 		opts.PrintTime,
 		opts.PrintPriority,

--- a/buildlogger/get_test.go
+++ b/buildlogger/get_test.go
@@ -247,7 +247,7 @@ func (h *mockHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func getParams(opts BuildloggerGetOptions) string {
 	params := fmt.Sprintf(
 		"?execution=%d&proc_name=%s&print_time=%v&print_priority=%v&n=%d&limit=%d&paginate=true",
-		opts.Execution,
+		opts.CedarOpts.Execution,
 		opts.ProcessName,
 		opts.PrintTime,
 		opts.PrintPriority,

--- a/get_options.go
+++ b/get_options.go
@@ -21,9 +21,10 @@ type GetOptions struct {
 	// Request information. See cedar's REST documentation for more
 	// information:
 	// `https://github.com/evergreen-ci/cedar/wiki/Rest-V1-Usage`.
-	ID       string
-	TaskID   string
-	TestName string
+	ID        string
+	TaskID    string
+	TestName  string
+	Execution int
 }
 
 // Validate ensures GetOptions is configured correctly.

--- a/testresults/get.go
+++ b/testresults/get.go
@@ -25,6 +25,7 @@ func GetTestResults(ctx context.Context, opts timber.GetOptions) ([]byte, error)
 	if opts.TestName != "" {
 		url += fmt.Sprintf("/%s", opts.TestName)
 	}
+	url += fmt.Sprintf("?execution=%d", opts.Execution)
 
 	catcher := grip.NewBasicCatcher()
 	resp, err := opts.DoReq(ctx, url)


### PR DESCRIPTION
Just adds `execution` option to the general get options, and adds execution as a parameter to the test results route.