### PR TITLE
EVG-13468: Enable in prefixes for buildlogger

### DIFF
--- a/buildlogger/basic_sender.go
+++ b/buildlogger/basic_sender.go
@@ -2,6 +2,7 @@ package buildlogger
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 	"sync"
@@ -98,6 +99,9 @@ type LoggerOptions struct {
 
 	// Storage location type for this log.
 	Storage LogStorage `bson:"storage" json:"storage" yaml:"storage"`
+
+	// Prefix for log lines, if any.
+	Prefix string `bson:"prefix" jason:"prefix" yaml:"prefix"`
 
 	// Configure a local sender for "fallback" operations and to collect
 	// the location of the buildlogger output.
@@ -294,10 +298,14 @@ func (b *buildlogger) Send(m message.Composer) {
 		if line == "" {
 			continue
 		}
+		data := strings.TrimRightFunc(line, unicode.IsSpace)
+		if b.opts.Prefix != "" {
+			data = fmt.Sprintf("[%s] %s", b.opts.Prefix, data)
+		}
 		logLine := &gopb.LogLine{
 			Priority:  int32(m.Priority()),
 			Timestamp: &timestamp.Timestamp{Seconds: ts.Unix(), Nanos: int32(ts.Nanosecond())},
-			Data:      strings.TrimRightFunc(line, unicode.IsSpace),
+			Data:      data,
 		}
 
 		b.buffer = append(b.buffer, logLine)

--- a/buildlogger/basic_sender.go
+++ b/buildlogger/basic_sender.go
@@ -32,9 +32,9 @@ type LogFormat int32
 // Valid LogFormat values.
 const (
 	LogFormatUnknown LogFormat = 0
-	LogFormatText    LogFormat = 1
-	LogFormatJSON    LogFormat = 2
-	LogFormatBSON    LogFormat = 3
+	LogFormatJSON    LogFormat = 1
+	LogFormatBSON    LogFormat = 2
+	LogFormatText    LogFormat = 3
 )
 
 func (f LogFormat) validate() error {

--- a/buildlogger/basic_sender.go
+++ b/buildlogger/basic_sender.go
@@ -32,9 +32,9 @@ type LogFormat int32
 // Valid LogFormat values.
 const (
 	LogFormatUnknown LogFormat = 0
-	LogFormatJSON    LogFormat = 1
-	LogFormatBSON    LogFormat = 2
-	LogFormatText    LogFormat = 3
+	LogFormatText    LogFormat = 1
+	LogFormatJSON    LogFormat = 2
+	LogFormatBSON    LogFormat = 3
 )
 
 func (f LogFormat) validate() error {

--- a/buildlogger/basic_sender_test.go
+++ b/buildlogger/basic_sender_test.go
@@ -560,6 +560,20 @@ func TestSend(t *testing.T) {
 		assert.Equal(t, m2.String(), b.buffer[2].Data)
 		assert.EqualValues(t, m.Priority(), b.buffer[2].Priority)
 	})
+	t.Run("WithPrefix", func(t *testing.T) {
+		mc := &mockClient{}
+		ms := &mockSender{Base: send.NewBase("test")}
+		b := createSender(ctx, mc, ms)
+		b.opts.MaxBufferSize = 4096
+		b.opts.Prefix = "prefix"
+
+		m := message.ConvertToComposer(level.Emergency, "Hello world!")
+		b.Send(m)
+		require.NoError(t, b.Close())
+		require.Len(t, mc.logLines.Lines, 1)
+		assert.Equal(t, fmt.Sprintf("[%s] %s", b.opts.Prefix, m.String()), mc.logLines.Lines[0].Data)
+		assert.EqualValues(t, m.Priority(), mc.logLines.Lines[0].Priority)
+	})
 	t.Run("RPCError", func(t *testing.T) {
 		str := "overflow"
 		mc := &mockClient{appendErr: true}

--- a/buildlogger/logger_producer.go
+++ b/buildlogger/logger_producer.go
@@ -10,7 +10,6 @@ import (
 // options.LoggerProducer for BuildloggerV3.
 type JasperLoggerOptions struct {
 	Name          string         `json:"name" bson:"name"`
-	Prefix        string         `json:"prefix" bson:"prefix"`
 	Level         send.LevelInfo `json:"level" bson:"level"`
 	BuildloggerV3 LoggerOptions  `json:"buildloggerv3" bson:"buildloggerv3"`
 }

--- a/buildlogger/logger_producer.go
+++ b/buildlogger/logger_producer.go
@@ -10,6 +10,7 @@ import (
 // options.LoggerProducer for BuildloggerV3.
 type JasperLoggerOptions struct {
 	Name          string         `json:"name" bson:"name"`
+	Prefix        string         `json:"prefix" bson:"prefix"`
 	Level         send.LevelInfo `json:"level" bson:"level"`
 	BuildloggerV3 LoggerOptions  `json:"buildloggerv3" bson:"buildloggerv3"`
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13468

Enables a prefix for each log line in the buildlogger sender.