### PR TITLE
EVG-15006: Do not check bytes read when checking for EOF in paginated reader

### DIFF
--- a/buildlogger/get.go
+++ b/buildlogger/get.go
@@ -138,7 +138,7 @@ func (r *paginatedReadCloser) Read(p []byte) (int, error) {
 	for offset < len(p) {
 		n, err = r.ReadCloser.Read(p[offset:])
 		offset += n
-		if err == io.EOF && n > 0 {
+		if err == io.EOF {
 			err = r.getNextPage()
 		}
 		if err != nil {

--- a/buildlogger/get_test.go
+++ b/buildlogger/get_test.go
@@ -261,8 +261,8 @@ type mockHandler struct {
 
 func (h *mockHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if h.pages > 0 {
-		w.Header().Set("Link", fmt.Sprintf("<%s>; rel=\"%s\"", h.baseURL, "next"))
 		if h.count <= h.pages-1 {
+			w.Header().Set("Link", fmt.Sprintf("<%s>; rel=\"%s\"", h.baseURL, "next"))
 			_, _ = w.Write([]byte(fmt.Sprintf("PAGINATED BODY PAGE %d\n", h.count+1)))
 		}
 		h.count++


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-15006