### PR TITLE
EVG-15479, EVG-15495: remove GO_BIN_PATH and fix linter PATH

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -53,7 +53,7 @@ functions:
       working_dir: gopath/src/github.com/evergreen-ci/timber
       binary: make
       args: ["${target}"]
-      include_expansions_in_env: ["DISABLE_COVERAGE", "GO_BIN_PATH", "GOROOT", "RACE_DETECTOR"]
+      include_expansions_in_env: ["DISABLE_COVERAGE", "GOROOT", "RACE_DETECTOR"]
       env:
         GOPATH: ${workdir}/gopath
         AWS_KEY: ${aws_key}
@@ -127,7 +127,6 @@ buildvariants:
     display_name: Race Detector (Arch Linux)
     expansions:
       DISABLE_COVERAGE: true
-      GO_BIN_PATH: /opt/golang/go1.16/bin/go
       GOROOT: /opt/golang/go1.16
       RACE_DETECTOR: true
       mongodb_url: http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.1.tgz
@@ -139,7 +138,6 @@ buildvariants:
   - name: coverage
     display_name: Coverage (Arch Linux)
     expansions:
-      GO_BIN_PATH: /opt/golang/go1.16/bin/go
       GOROOT: /opt/golang/go1.16
       mongodb_url: http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.1.tgz
     run_on:
@@ -151,7 +149,6 @@ buildvariants:
     display_name: Ubuntu 18.04
     expansions:
       DISABLE_COVERAGE: true
-      GO_BIN_PATH: /opt/golang/go1.16/bin/go
       GOROOT: /opt/golang/go1.16
       mongodb_url: http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.1.tgz
     run_on:
@@ -163,7 +160,6 @@ buildvariants:
     display_name: macOS 10.14
     expansions:
       DISABLE_COVERAGE: true
-      GO_BIN_PATH: /opt/golang/go1.16/bin/go
       GOROOT: /opt/golang/go1.16
       mongodb_url: https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.1.tgz
     run_on:
@@ -181,7 +177,6 @@ buildvariants:
     expansions:
       DISABLE_COVERAGE: true
       GOROOT: C:/golang/go1.16
-      GO_BIN_PATH: /cygdrive/c/golang/go1.16/bin/go
       mongodb_url: https://fastdl.mongodb.org/win32/mongodb-win32-x86_64-2008plus-ssl-4.0.1.zip
     tasks:
       - name: ".test"

--- a/makefile
+++ b/makefile
@@ -1,47 +1,77 @@
+# start project configuration
 name := timber
 buildDir := build
-
 packages := $(name) timber buildlogger systemmetrics testresults testutil
 testPackages := timber buildlogger systemmetrics testresults
+compilePackages := $(subst $(name),,$(subst -,/,$(foreach target,$(packages),./$(target))))
+projectPath := github.com/evergreen-ci/timber
+# end project configuration
 
 # start environment setup
-gobin := $(GO_BIN_PATH)
-ifeq ($(gobin),)
-	gobin := go
-endif
-gopath := $(GOPATH)
-gocache := $(abspath $(buildDir)/.cache)
-goroot := $(GOROOT)
-ifeq ($(OS),Windows_NT)
-	gocache := $(shell cygpath -m $(gocache))
-	gopath := $(shell cygpath -m $(gopath))
-	goroot := $(shell cygpath -m $(goroot))
+gobin := go
+ifneq (,$(GOROOT))
+gobin := $(GOROOT)/bin/go
 endif
 
-export GOPATH := $(gopath)
-export GOCACHE := $(gocache)
-export GOROOT := $(goroot)
+ifeq ($(OS),Windows_NT)
+gobin := $(shell cygpath $(gobin))
+export GOCACHE := $(shell cygpath -m $(abspath $(buildDir)/.cache))
+export GOLANGCI_LINT_CACHE := $(shell cygpath -m $(abspath $(buildDir)/.lint-cache))
+export GOPATH := $(shell cygpath -m $(GOPATH))
+export GOROOT := $(shell cygpath -m $(GOROOT))
+endif
+
 export GO111MODULE := off
 # end environment setup
-
 
 # Ensure the build directory exists, since most targets require it.
 $(shell mkdir -p $(buildDir))
 
+.DEFAULT_GOAL := compile
 
 # start lint setup targets
 lintDeps := $(buildDir)/run-linter $(buildDir)/golangci-lint
 $(buildDir)/golangci-lint:
 	@curl --retry 10 --retry-max-time 60 -sSfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(buildDir) v1.40.0 >/dev/null 2>&1
-$(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
+$(buildDir)/run-linter:  cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
 	@$(gobin) build -o $@ $<
 # end lint setup targets
 
+# start output files
 testOutput := $(foreach target,$(testPackages),$(buildDir)/output.$(target).test)
 lintOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).lint)
 coverageOutput := $(foreach target,$(testPackages),$(buildDir)/output.$(target).coverage)
 coverageHtmlOutput := $(foreach target,$(testPackages),$(buildDir)/output.$(target).coverage.html)
+.PRECIOUS:$(coverageOutput) $(coverageHtmlOutput) $(lintOutput) $(testOutput)
+# end output files
 
+# start basic development operations
+compile:
+	$(gobin) build $(compilePackages)
+test: $(testOutput)
+	
+coverage: $(coverageOutput)
+	
+coverage-html: $(coverageHtmlOutput)
+	
+lint: $(lintOutput)
+	
+phony += compile lint test coverage coverage-html
+
+# start convenience targets for running tests and coverage tasks on a
+# specific package.
+test-%:$(buildDir)/output.%.test
+	
+coverage-%:$(buildDir)/output.%.coverage
+	@grep -s -q -e "^PASS" $(buildDir)/output.$*.test
+html-coverage-%:$(buildDir)/output.%.coverage.html
+	@grep -s -q -e "^PASS" $(buildDir)/output.$*.test
+lint-%:$(buildDir)/output.%.lint
+	@grep -v -s -q "^--- FAIL" $<
+# end convenience targets
+# end basic development operations
+
+# start test and coverage artifacts
 testArgs := -v
 ifeq (,$(DISABLE_COVERAGE))
 	testArgs += -cover
@@ -58,50 +88,28 @@ endif
 ifneq (,$(SKIP_LONG))
 	testArgs += -short
 endif
-
-test:$(testOutput)
-	
-coverage:$(coverageOutput)
-	@$(gobin) tool cover -func=$< | sed -E 's%github.com/.*/jasper/%%' | column -t
-coverage-html:$(coverageHtmlOutput)
-	
-lint:$(lintOutput)
-	
-phony += lint $(buildDir) race test coverage coverage-html
-.PRECIOUS:$(coverageOutput) $(coverageHtmlOutput) $(lintOutput) $(testOutput)
-
-
-compile $(buildDir):
-	$(gobin) build $(subst $(name),,$(subst -,/,$(foreach target,$(packages),./$(target))))
-# test execution and output handlers
 $(buildDir)/output.%.test: .FORCE
 	$(gobin) test $(testArgs) ./$(if $(subst $(name),,$*),$(subst -,/,$*),) | tee $@
 	@!( grep -s -q "^FAIL" $@ && grep -s -q "^WARNING: DATA RACE" $@)
 	@(grep -s -q "^PASS" $@ || grep -s -q "no test files" $@)
-#  targets to process and generate coverage reports
-$(buildDir)/output.%.coverage:.FORCE
+$(buildDir)/output.%.coverage: .FORCE
 	$(gobin) test $(testArgs) ./$(if $(subst $(name),,$*),$(subst -,/,$*),) -covermode=count -coverprofile $@ | tee $(buildDir)/output.$*.test
 	@-[ -f $@ ] && $(gobin) tool cover -func=$@ | sed 's%$(projectPath)/%%' | column -t
-$(buildDir)/output.%.coverage.html:$(buildDir)/output.%.coverage
+$(buildDir)/output.%.coverage.html: $(buildDir)/output.%.coverage
 	$(gobin) tool cover -html=$< -o $@
-#  targets to generate gotest output from the linter.
-# We have to handle the PATH specially for CI, because if the PATH has a different version of Go in it, it'll break.
+
+ifneq (go,$(gobin))
+# We have to handle the PATH specially for linting in CI, because if the PATH has a different version of the Go
+# binary in it, the linter won't work properly.
+lintEnvVars := PATH="$(shell dirname $(gobin)):$(PATH)"
+endif
 $(buildDir)/output.%.lint: $(buildDir)/run-linter .FORCE
-	@$(if $(GO_BIN_PATH), PATH="$(shell dirname $(GO_BIN_PATH)):$(PATH)") ./$< --output=$@ --lintBin=$(buildDir)/golangci-lint --packages='$*'
+	@$(lintEnvVars) ./$< --output=$@ --lintBin=$(buildDir)/golangci-lint --packages='$*'
 # end test and coverage artifacts
 
-.FORCE:
-
-clean:
-	rm -rf $(lintDeps)
-clean-results:
-	rm -rf $(buildDir)/output.*
-
+# start vendoring configuration
 vendor:
 	glide install -s
-
-
-.PHONY:vendor
 vendor-clean:
 	rm -rf vendor/github.com/mongodb/grip/vendor/golang.org/x/oauth2/
 	rm -rf vendor/github.com/mongodb/grip/vendor/golang.org/x/sys/
@@ -126,15 +134,16 @@ vendor-clean:
 	rm -rf vendor/go.mongodb.org/mongo-driver/data/
 	find vendor/ -name "*.gif" -o -name "*.gz" -o -name "*.png" -o -name "*.ico" -o -name "*.dat" -o -name "*testdata" | xargs rm -rf
 	find vendor/ -name .git | xargs rm -rf
+phony += vendor-clean
+# end vendoring configuration
 
-# convenience targets for runing tests and coverage tasks on a
-# specific package.
-test-%:$(buildDir)/output.%.test
-	
-coverage-%:$(buildDir)/output.%.coverage
-	@grep -s -q -e "^PASS" $(buildDir)/output.$*.test
-html-coverage-%:$(buildDir)/output.%.coverage.html
-	@grep -s -q -e "^PASS" $(buildDir)/output.$*.test
-lint-%:$(buildDir)/output.%.lint
-	@grep -v -s -q "^--- FAIL" $<
-# end convienence targets
+# start cleanup targets
+clean:
+	rm -rf $(buildDir)
+clean-results:
+	rm -rf $(buildDir)/output.*
+# end cleanup targets
+
+# configure phony targets
+.FORCE:
+.PHONY: $(phony)


### PR DESCRIPTION
Jira:
https://jira.mongodb.org/browse/EVG-15479
https://jira.mongodb.org/browse/EVG-15495

* Remove GO_BIN_PATH. CI tests now depend on GOROOT to tell them which Go version to use and which Go binary to use.
* Set the GOLANGCI_LINT_CACHE, which is used to control where golangci-lint caches information. By default, golangci-lint will use the user's cache directory (usually in the home directory). This prevents the CI linter from writing outside of the working directory.
* Fix setting the PATH variable for the linter.
* Clean up and standardize the makefile.