### PR TITLE
EVG-15682: remove DISABLE_COVERAGE flag

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -108,7 +108,7 @@ tasks:
 
   - <<: *run-build
     tags: [ "report" ]
-    name: coverage-html
+    name: html-coverage
 
   - <<: *run-build
     tags: ["test"]

--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -39,7 +39,7 @@ functions:
       working_dir: timber
       binary: make
       args: ["${target}"]
-      include_expansions_in_env: ["DISABLE_COVERAGE", "GOROOT", "RACE_DETECTOR"]
+      include_expansions_in_env: ["GOROOT", "RACE_DETECTOR"]
       env:
         AWS_KEY: ${aws_key}
         AWS_SECRET: ${aws_secret}
@@ -133,7 +133,6 @@ buildvariants:
   - name: race-detector
     display_name: Race Detector (Arch Linux)
     expansions:
-      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
       RACE_DETECTOR: true
     run_on:
@@ -153,7 +152,6 @@ buildvariants:
   - name: ubuntu
     display_name: Ubuntu 18.04
     expansions:
-      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
     run_on:
       - ubuntu1804-small
@@ -163,7 +161,6 @@ buildvariants:
   - name: macos
     display_name: macOS 10.14
     expansions:
-      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
     run_on:
       - macos-1014
@@ -178,7 +175,6 @@ buildvariants:
       - windows-64-vs2017-small
       - windows-64-vs2017-large
     expansions:
-      DISABLE_COVERAGE: true
       GOROOT: C:/golang/go1.16
     tasks:
       - name: ".test"

--- a/makefile
+++ b/makefile
@@ -60,7 +60,7 @@ $(shell mkdir -p $(buildDir))
 # start lint setup targets
 $(buildDir)/golangci-lint:
 	@curl --retry 10 --retry-max-time 60 -sSfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(buildDir) v1.40.0 >/dev/null 2>&1
-$(buildDir)/run-linter:  cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
+$(buildDir)/run-linter: cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
 	@$(gobin) build -o $@ $<
 # end lint setup targets
 
@@ -68,8 +68,8 @@ $(buildDir)/run-linter:  cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
 testOutput := $(foreach target,$(testPackages),$(buildDir)/output.$(target).test)
 lintOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).lint)
 coverageOutput := $(foreach target,$(testPackages),$(buildDir)/output.$(target).coverage)
-coverageHtmlOutput := $(foreach target,$(testPackages),$(buildDir)/output.$(target).coverage.html)
-.PRECIOUS:$(coverageOutput) $(coverageHtmlOutput) $(lintOutput) $(testOutput)
+htmlCoverageOutput := $(foreach target,$(testPackages),$(buildDir)/output.$(target).coverage.html)
+.PRECIOUS: $(coverageOutput) $(htmlCoverageOutput) $(lintOutput) $(testOutput)
 # end output files
 
 # start basic development operations
@@ -79,11 +79,11 @@ test: $(testOutput)
 	
 coverage: $(coverageOutput)
 	
-coverage-html: $(coverageHtmlOutput)
+html-coverage: $(htmlCoverageOutput)
 	
 lint: $(lintOutput)
 	
-phony += compile lint test coverage coverage-html
+phony += compile lint test coverage html-coverage
 
 # start convenience targets for running tests and coverage tasks on a
 # specific package.

--- a/makefile
+++ b/makefile
@@ -100,9 +100,6 @@ lint-%:$(buildDir)/output.%.lint
 
 # start test and coverage artifacts
 testArgs := -v
-ifeq (,$(DISABLE_COVERAGE))
-	testArgs += -cover
-endif
 ifneq (,$(RACE_DETECTOR))
 	testArgs += -race
 endif


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15682

Remove the `DISABLE_COVERAGE` flag. The only thing that this does is when you run `make test-<package>`, it adds a summary line at the end of the go test output to include the percentage of lines covered that looks like this:
```
coverage:  <N>% of statements
```
I don't think this is particularly useful - instead, it's more useful is to run `make coverage-<package>` or `make html-coverage-<package>`, which produces more detailed information about code coverage rather than a single aggregate coverage number. Those coverage targets do not depend on `DISABLE_COVERAGE`.