### PR TITLE
EVG-15242: Add optional http client to GetOptions

### DIFF
--- a/get_options.go
+++ b/get_options.go
@@ -2,6 +2,7 @@ package timber
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -10,15 +11,17 @@ import (
 )
 
 // GetOptions specify the required and optional information to create an HTTP
-// GET request to cedar.
+// GET request to Cedar.
 type GetOptions struct {
-	// The cedar service's base HTTP URL for the request.
+	// The Cedar service's base HTTP URL for the request.
 	BaseURL string
-	// The user cookie for cedar authorization. Optional.
+	// The user cookie for Cedar authorization. Optional.
 	Cookie *http.Cookie
 	// User API key and name for request header.
 	UserKey  string
 	UserName string
+	// HTTP client for connecting to the Cedar service. Optional.
+	HTTPClient *http.Client
 }
 
 // Validate ensures GetOptions is configured correctly.
@@ -30,11 +33,11 @@ func (opts GetOptions) Validate() error {
 	return nil
 }
 
-// DoReq makes an HTTP request to the cedar service.
+// DoReq makes an HTTP request to the Cedar service.
 func (opts GetOptions) DoReq(ctx context.Context, url string, body io.Reader) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, body)
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating http request for cedar")
+		return nil, errors.Wrap(err, "creating http request for Cedar")
 	}
 	if opts.Cookie != nil {
 		req.AddCookie(opts.Cookie)
@@ -44,8 +47,12 @@ func (opts GetOptions) DoReq(ctx context.Context, url string, body io.Reader) (*
 		req.Header.Set("Evergreen-Api-User", opts.UserName)
 	}
 
-	c := utility.GetHTTPClient()
-	defer utility.PutHTTPClient(c)
+	c := opts.HTTPClient
+	fmt.Println(c)
+	if c == nil {
+		c = utility.GetHTTPClient()
+		defer utility.PutHTTPClient(c)
+	}
 
 	return c.Do(req)
 }

--- a/get_options.go
+++ b/get_options.go
@@ -2,7 +2,6 @@ package timber
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net/http"
 
@@ -48,7 +47,6 @@ func (opts GetOptions) DoReq(ctx context.Context, url string, body io.Reader) (*
 	}
 
 	c := opts.HTTPClient
-	fmt.Println(c)
 	if c == nil {
 		c = utility.GetHTTPClient()
 		defer utility.PutHTTPClient(c)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-15242

This is offers more flexibility when using the timber REST clients, especially for testing.