### PR TITLE
EVG-18728: Remove historical test data field from the client and update juniper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/evergreen-ci/aviation v0.0.0-20220405151811-ff4a78a4297c
-	github.com/evergreen-ci/juniper v0.0.0-20220118233332-0813edc78908
+	github.com/evergreen-ci/juniper v0.0.0-20230119161755-1aced8006202
 	github.com/evergreen-ci/utility v0.0.0-20220404192535-d16eb64796e6
 	github.com/mongodb/grip v0.0.0-20220401165023-6a1d9bb90c21
 	github.com/peterhellberg/link v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,8 @@ github.com/evergreen-ci/gimlet v0.0.0-20220401151443-33c830c51cee h1:+4jp62usQsV
 github.com/evergreen-ci/gimlet v0.0.0-20220401151443-33c830c51cee/go.mod h1:NqXYQ2lPMU7dY33a4ZrqXJKQ3ZY8IZru8H/rpY0hrxs=
 github.com/evergreen-ci/juniper v0.0.0-20220118233332-0813edc78908 h1:k7f+q2yaOdv+SNSV2iHhqdBIxA8Yk78CLGypk8d+efI=
 github.com/evergreen-ci/juniper v0.0.0-20220118233332-0813edc78908/go.mod h1:LewZWRe1jV5XJhNksoB0rpvlwsg+D6M3yvzIFJZ8OJs=
+github.com/evergreen-ci/juniper v0.0.0-20230119161755-1aced8006202 h1:MK0NYjJ1XHqvXMKwwV7uJC/6vOsLDuSUDoWmy9wahck=
+github.com/evergreen-ci/juniper v0.0.0-20230119161755-1aced8006202/go.mod h1:LewZWRe1jV5XJhNksoB0rpvlwsg+D6M3yvzIFJZ8OJs=
 github.com/evergreen-ci/negroni v1.0.1-0.20211028183800-67b6d7c2c035 h1:oVU/ni/sRq+GAogUMLa7LBGtvVHMVLbisuytxBC5KaY=
 github.com/evergreen-ci/negroni v1.0.1-0.20211028183800-67b6d7c2c035/go.mod h1:pvK7NM0ZC+sfTLuIiJN4BgM1S9S5Oo79PJReAFFph18=
 github.com/evergreen-ci/utility v0.0.0-20220404192535-d16eb64796e6 h1:K7gQ8KBfq3wH8+BSSjZG9ZdD9P5KO2XZJxVQeg0eUW8=

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,6 @@ github.com/evergreen-ci/aviation v0.0.0-20220405151811-ff4a78a4297c/go.mod h1:5A
 github.com/evergreen-ci/gimlet v0.0.0-20220401150826-5898de01dbd8/go.mod h1:LfnJ3oYEVFUHwIPoAotvn9bbtAT+lAaCpH5YYnyxluk=
 github.com/evergreen-ci/gimlet v0.0.0-20220401151443-33c830c51cee h1:+4jp62usQsVoZb/KTYT7DetD04hbcXPjP/XhjJq0zws=
 github.com/evergreen-ci/gimlet v0.0.0-20220401151443-33c830c51cee/go.mod h1:NqXYQ2lPMU7dY33a4ZrqXJKQ3ZY8IZru8H/rpY0hrxs=
-github.com/evergreen-ci/juniper v0.0.0-20220118233332-0813edc78908 h1:k7f+q2yaOdv+SNSV2iHhqdBIxA8Yk78CLGypk8d+efI=
-github.com/evergreen-ci/juniper v0.0.0-20220118233332-0813edc78908/go.mod h1:LewZWRe1jV5XJhNksoB0rpvlwsg+D6M3yvzIFJZ8OJs=
 github.com/evergreen-ci/juniper v0.0.0-20230119161755-1aced8006202 h1:MK0NYjJ1XHqvXMKwwV7uJC/6vOsLDuSUDoWmy9wahck=
 github.com/evergreen-ci/juniper v0.0.0-20230119161755-1aced8006202/go.mod h1:LewZWRe1jV5XJhNksoB0rpvlwsg+D6M3yvzIFJZ8OJs=
 github.com/evergreen-ci/negroni v1.0.1-0.20211028183800-67b6d7c2c035 h1:oVU/ni/sRq+GAogUMLa7LBGtvVHMVLbisuytxBC5KaY=

--- a/testresults/client_test.go
+++ b/testresults/client_test.go
@@ -89,8 +89,6 @@ func TestClient(t *testing.T) {
 			assert.Equal(t, exportedOpts.Execution, srv.Create.Execution)
 			assert.Equal(t, exportedOpts.RequestType, srv.Create.RequestType)
 			assert.Equal(t, exportedOpts.Mainline, srv.Create.Mainline)
-			assert.Equal(t, exportedOpts.HistoricalDataIgnore, srv.Create.HistoricalDataIgnore)
-			assert.Equal(t, exportedOpts.HistoricalDataDisabled, srv.Create.HistoricalDataDisabled)
 		},
 		"CreateRecordFailsWithServerError": func(ctx context.Context, t *testing.T, srv *testutil.MockTestResultsServer, client *Client) {
 			srv.CreateErr = true
@@ -190,16 +188,14 @@ func TestClient(t *testing.T) {
 
 func validCreateOptions() CreateOptions {
 	return CreateOptions{
-		Project:                "project",
-		Version:                "version",
-		Variant:                "variant",
-		TaskID:                 "task_id",
-		TaskName:               "task_name",
-		DisplayTaskName:        "display_task_name",
-		DisplayTaskID:          "display_task_id",
-		RequestType:            "request_type",
-		HistoricalDataIgnore:   []string{"ignoreMe"},
-		HistoricalDataDisabled: true,
+		Project:         "project",
+		Version:         "version",
+		Variant:         "variant",
+		TaskID:          "task_id",
+		TaskName:        "task_name",
+		DisplayTaskName: "display_task_name",
+		DisplayTaskID:   "display_task_id",
+		RequestType:     "request_type",
 	}
 }
 

--- a/testresults/options.go
+++ b/testresults/options.go
@@ -10,34 +10,30 @@ import (
 
 // CreateOptions represent options to create a new test results record.
 type CreateOptions struct {
-	Project                string   `bson:"project" json:"project" yaml:"project"`
-	Version                string   `bson:"version" json:"version" yaml:"version"`
-	Variant                string   `bson:"variant" json:"variant" yaml:"variant"`
-	TaskID                 string   `bson:"task_id" json:"task_id" yaml:"task_id"`
-	TaskName               string   `bson:"task_name" json:"task_name" yaml:"task_name"`
-	DisplayTaskName        string   `bson:"display_task_name" json:"display_task_name" yaml:"display_task_name"`
-	DisplayTaskID          string   `bson:"display_task_id" json:"display_task_id" yaml:"display_task_id"`
-	Execution              int32    `bson:"execution" json:"execution" yaml:"execution"`
-	RequestType            string   `bson:"request_type" json:"request_type" yaml:"request_type"`
-	Mainline               bool     `bson:"mainline" json:"mainline" yaml:"mainline"`
-	HistoricalDataIgnore   []string `bson:"historical_data_ignore" json:"historical_data_ignore" yaml:"historical_data_ignore"`
-	HistoricalDataDisabled bool     `bson:"historical_data_disabled" json:"historical_data_disabled" yaml:"historical_data_disabled"`
+	Project         string `bson:"project" json:"project" yaml:"project"`
+	Version         string `bson:"version" json:"version" yaml:"version"`
+	Variant         string `bson:"variant" json:"variant" yaml:"variant"`
+	TaskID          string `bson:"task_id" json:"task_id" yaml:"task_id"`
+	TaskName        string `bson:"task_name" json:"task_name" yaml:"task_name"`
+	DisplayTaskName string `bson:"display_task_name" json:"display_task_name" yaml:"display_task_name"`
+	DisplayTaskID   string `bson:"display_task_id" json:"display_task_id" yaml:"display_task_id"`
+	Execution       int32  `bson:"execution" json:"execution" yaml:"execution"`
+	RequestType     string `bson:"request_type" json:"request_type" yaml:"request_type"`
+	Mainline        bool   `bson:"mainline" json:"mainline" yaml:"mainline"`
 }
 
 func (opts CreateOptions) export() *gopb.TestResultsInfo {
 	return &gopb.TestResultsInfo{
-		Project:                opts.Project,
-		Version:                opts.Version,
-		Variant:                opts.Variant,
-		TaskName:               opts.TaskName,
-		TaskId:                 opts.TaskID,
-		DisplayTaskName:        opts.DisplayTaskName,
-		DisplayTaskId:          opts.DisplayTaskID,
-		Execution:              opts.Execution,
-		RequestType:            opts.RequestType,
-		Mainline:               opts.Mainline,
-		HistoricalDataIgnore:   opts.HistoricalDataIgnore,
-		HistoricalDataDisabled: opts.HistoricalDataDisabled,
+		Project:         opts.Project,
+		Version:         opts.Version,
+		Variant:         opts.Variant,
+		TaskName:        opts.TaskName,
+		TaskId:          opts.TaskID,
+		DisplayTaskName: opts.DisplayTaskName,
+		DisplayTaskId:   opts.DisplayTaskID,
+		Execution:       opts.Execution,
+		RequestType:     opts.RequestType,
+		Mainline:        opts.Mainline,
 	}
 }
 


### PR DESCRIPTION
EVG-18728: https://jira.mongodb.org/browse/EVG-18728

This updates juniper (protobuf library) and removes the historical test data fields from the test results client options.
