### PR TITLE
EVG-20455: add new ExcludeDisplayNames field to the test results client

### DIFF
--- a/testresults/get.go
+++ b/testresults/get.go
@@ -50,13 +50,14 @@ type SortBy struct {
 // FilterOptions represent the parameters for filtering, sorting, and
 // paginating test results. These options are only supported on select routes.
 type FilterOptions struct {
-	TestName  string        `json:"test_name,omitempty"`
-	Statuses  []string      `json:"statuses,omitempty"`
-	GroupID   string        `json:"group_id,omitempty"`
-	Sort      []SortBy      `json:"sort"`
-	Limit     int           `json:"limit,omitempty"`
-	Page      int           `json:"page,omitempty"`
-	BaseTasks []TaskOptions `json:"base_tasks,omitempty"`
+	TestName            string        `json:"test_name,omitempty"`
+	ExcludeDisplayNames bool          `json:"exclude_display_names"`
+	Statuses            []string      `json:"statuses,omitempty"`
+	GroupID             string        `json:"group_id,omitempty"`
+	Sort                []SortBy      `json:"sort"`
+	Limit               int           `json:"limit,omitempty"`
+	Page                int           `json:"page,omitempty"`
+	BaseTasks           []TaskOptions `json:"base_tasks,omitempty"`
 }
 
 type requestPayload struct {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-20455

https://github.com/evergreen-ci/cedar/pull/520 adds a new field `exclude_display_names` to the JSON request body that the test results route expects. This updates the client.